### PR TITLE
add cuhk dataset

### DIFF
--- a/imgori/datasets/blur/__init__.py
+++ b/imgori/datasets/blur/__init__.py
@@ -1,0 +1,2 @@
+from .cuhk import CUHKDataLoader
+from .cuhk import CUHKDataset

--- a/imgori/datasets/blur/cuhk.py
+++ b/imgori/datasets/blur/cuhk.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from typing import Any
+
+import torch
+from loguru import logger
+from PIL import Image
+from torch.utils.data import DataLoader
+from torch.utils.data import Dataset
+from torchvision import tv_tensors
+from torchvision.transforms import v2
+
+
+def make_dataset(root: str) -> tuple[Path, Path]:
+    root = Path(root)
+
+    image_dir: Path = root / "image"
+    gt_dir: Path = root / "gt"
+
+    samples = []
+    for img_path in image_dir.rglob("*"):
+        if img_path.suffix.lower() != ".jpg":
+            logger.warning(f"Unsupported image format: {img_path}")
+            continue
+
+        gt_path = gt_dir / img_path.relative_to(image_dir).with_suffix(".png")
+
+        if gt_path.exists():
+            samples.append((img_path, gt_path))
+        else:
+            logger.warning(f"GT not found: {gt_path}")
+
+    return samples
+
+
+class CUHKDataset(Dataset):
+    def __init__(self, root: str, transform=None) -> None:
+        self.root = Path(root)
+        self.transform = transform
+        self.samples = make_dataset(root)
+
+    def __getitem__(self, index: int) -> Any:
+        img_path, gt_path = self.samples[index]
+
+        img = tv_tensors.Image(Image.open(img_path).convert("RGB"))
+        gt = tv_tensors.Mask(Image.open(gt_path).convert("L"))
+
+        if self.transform is not None:
+            img, gt = self.transform(img, gt)
+
+        return img, gt
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+
+class CUHKDataLoader(DataLoader):
+    def __init__(self, root: str, **kwargs) -> None:
+        transform = v2.Compose(
+            [
+                v2.ToImage(),
+                v2.Resize(size=[224, 224]),
+                v2.ToDtype(torch.float32, scale=True),
+            ]
+        )
+        dataset = CUHKDataset(root, transform=transform)
+        super().__init__(
+            dataset,
+            # collate_fn=lambda batch: tuple(zip(*batch)),
+            **kwargs,
+        )


### PR DESCRIPTION
This pull request introduces new functionality for handling the CUHK dataset within the `imgori/datasets/blur` module. The most important changes include adding new imports, defining a function to create the dataset, and implementing a dataset class and a data loader class.

New imports and dataset creation:

* [`imgori/datasets/blur/__init__.py`](diffhunk://#diff-1b73e66ca560ffb958fdf74491e0f955de57050e598f6bffbfd90f543ae75a78R1-R2): Added imports for `CUHKDataLoader` and `CUHKDataset` to make them accessible from the module.
* [`imgori/datasets/blur/cuhk.py`](diffhunk://#diff-baf95f6dea0be7a98db9a19591710737580c78ef95d85456ec49211465984a25R1-R70): Added various imports including `Path`, `torch`, `loguru`, `PIL`, and `torchvision` to support dataset handling and transformations.

Dataset and DataLoader implementation:

* [`imgori/datasets/blur/cuhk.py`](diffhunk://#diff-baf95f6dea0be7a98db9a19591710737580c78ef95d85456ec49211465984a25R1-R70): Defined the `make_dataset` function to create a list of image and ground truth (GT) path tuples, with logging for unsupported formats and missing GT files.
* [`imgori/datasets/blur/cuhk.py`](diffhunk://#diff-baf95f6dea0be7a98db9a19591710737580c78ef95d85456ec49211465984a25R1-R70): Implemented the `CUHKDataset` class, which loads images and GT masks, applies transformations, and supports indexing and length operations.
* [`imgori/datasets/blur/cuhk.py`](diffhunk://#diff-baf95f6dea0be7a98db9a19591710737580c78ef95d85456ec49211465984a25R1-R70): Implemented the `CUHKDataLoader` class, which initializes a `CUHKDataset` with predefined transformations and extends `DataLoader` to facilitate batch processing.