### PR TITLE
add class index to CUHK

### DIFF
--- a/imgori/datasets/blur/cuhk.py
+++ b/imgori/datasets/blur/cuhk.py
@@ -9,6 +9,11 @@ from torch.utils.data import Dataset
 from torchvision import tv_tensors
 from torchvision.transforms import v2
 
+CLASS_TO_INDEX = {
+    "motion": 0,
+    "out_of_focus": 1,
+}
+
 
 def make_dataset(root: str) -> tuple[Path, Path]:
     root = Path(root)
@@ -32,6 +37,15 @@ def make_dataset(root: str) -> tuple[Path, Path]:
     return samples
 
 
+def get_class_index(path: Path) -> int:
+    if path.name.startswith("out_of_focus"):
+        return CLASS_TO_INDEX["out_of_focus"]
+    elif path.name.startswith("motion"):
+        return CLASS_TO_INDEX["motion"]
+    else:
+        raise ValueError(f"Unknown label: {path}")
+
+
 class CUHK(Dataset):
     def __init__(self, root: str, transform=None) -> None:
         """https://www.cse.cuhk.edu.hk/leojia/projects/dblurdetect/"""
@@ -48,7 +62,12 @@ class CUHK(Dataset):
         if self.transform is not None:
             img, gt = self.transform(img, gt)
 
-        return img, gt
+        class_index = get_class_index(gt_path)
+        return {
+            "image": img,
+            "mask": gt,
+            "class_index": class_index,
+        }
 
     def __len__(self) -> int:
         return len(self.samples)


### PR DESCRIPTION
This pull request includes several changes to the `imgori/datasets/blur/cuhk.py` file, focusing on adding class indexing and modifying the dataset retrieval method to include class information.

### Enhancements to class indexing:

* Added a `CLASS_TO_INDEX` dictionary to map blur types to indices. (`imgori/datasets/blur/cuhk.py`)
* Introduced a `get_class_index` function to determine the class index based on the file name. (`imgori/datasets/blur/cuhk.py`)

### Modifications to dataset retrieval:

* Updated the `__getitem__` method in the `CUHK` class to return a dictionary containing the image, mask, and class index instead of just the image and mask. (`imgori/datasets/blur/cuhk.py`)